### PR TITLE
Support multi-IP Ingresses & discover zone automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.python3
+/test*.json

--- a/cloudflared.sh
+++ b/cloudflared.sh
@@ -2,18 +2,11 @@
 
 # small IntelliJ hack to prevent warning on non-existing variables
 if [[ "THIS_WILL_NEVER_BE_TRUE" == "true" ]]; then
-    DOMAIN=${DOMAIN}
     AUTH_EMAIL=${AUTH_EMAIL}
     AUTH_KEY=${AUTH_KEY}
 fi
 
 while true; do
-    # read domain name
-    if [[ -z "${DOMAIN}" ]]; then
-        echo "DOMAIN environment variable not defined" >&2
-        exit 1
-    fi
-
     # read Cloudflare authentication Email
     if [[ -z "${AUTH_EMAIL}" ]]; then
         echo "AUTH_EMAIL environment variable not defined" >&2
@@ -38,7 +31,7 @@ while true; do
                         "name": .metadata.name,
                         ips: [.status.loadBalancer.ingress[].ip],
                         "dns": .metadata.annotations.dns|fromjson
-                    }]' | $(dirname $0)/update_dns_records.py "${DOMAIN}" "${AUTH_EMAIL}" "${AUTH_KEY}"
+                    }]' | $(dirname $0)/update_dns_records.py "${AUTH_EMAIL}" "${AUTH_KEY}"
     if [[ $? != 0 ]]; then
         echo "Updating service DNS records failed!" >&2
         exit 1
@@ -57,7 +50,7 @@ while true; do
                         "name": .metadata.name,
                         ips: [.status.loadBalancer.ingress[].ip],
                         "dns": [ .spec.rules[].host ]
-                    }]' | $(dirname $0)/update_dns_records.py "${DOMAIN}" "${AUTH_EMAIL}" "${AUTH_KEY}"
+                    }]' | $(dirname $0)/update_dns_records.py "${AUTH_EMAIL}" "${AUTH_KEY}"
     if [[ $? != 0 ]]; then
         echo "Updating ingress DNS records failed!" >&2
         exit 1

--- a/cloudflared.sh
+++ b/cloudflared.sh
@@ -48,6 +48,7 @@ while true; do
     # them to our Python script which will ensure their DNS records are correctly defined in Cloudflare
     kubectl get ingress --all-namespaces --output=json | jq -r '
                     [.items[] |
+                    select(.metadata.name | startswith( "kube-lego-" ) | not ) |
                     select(.status.loadBalancer) |
                     select(.status.loadBalancer.ingress) |
                     select(.status.loadBalancer.ingress[].ip) |

--- a/k8s-cloudflared.iml
+++ b/k8s-cloudflared.iml
@@ -6,4 +6,10 @@
     <orderEntry type="jdk" jdkName="Python 3.6 (k8s-cloudflared)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="PackageRequirementsSettings">
+    <option name="requirementsPath" value="" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
 </module>


### PR DESCRIPTION
Currently when an Ingress object has more than one IP associated with it, Cloudflared enters an infinite loop. This fixes it by supporting multiple IP address, while preserving existing functionality of removing extraneous DNS records.

Additionally, we now automatically find the Cloudflare zone for each Ingress host name automatically, thus supporting multi-domain Ingresses in the same cluster.